### PR TITLE
Fix build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-.PHONY: all clean install
+.PHONY: build clean install
 
-all:
+build:
 	jbuilder build 
 
 clean:

--- a/src/jbuild
+++ b/src/jbuild
@@ -5,6 +5,4 @@
   (public_name     lwt-pipe)
   (wrapped     false)
   (libraries       (lwt lwt.unix))
-  (flags           (:standard -w +a-4 -safe-string))
-  (preprocess
-    (pps (lwt_ppx)))))
+  (flags           (:standard -w +a-4 -safe-string))))


### PR DESCRIPTION
This change updates the build command to match the opam file, and allows installing lwt-pipe by following the instructions found in README. 