### PR TITLE
Function to check data availability

### DIFF
--- a/src/Lwt_pipe.mli
+++ b/src/Lwt_pipe.mli
@@ -38,6 +38,12 @@ type ('a, +'perm) t constraint 'perm = [< `r | `w]
 
 type ('a, 'perm) pipe = ('a, 'perm) t
 
+type availability =
+  | Pipe_closed
+  | Nothing_available
+  | Data_available
+(** Used as result of [values_available] *)
+
 val keep : (_,_) t -> unit Lwt.t -> unit
 (** [keep p fut] adds a pointer from [p] to [fut] so that [fut] is not
     garbage-collected before [p] *)
@@ -69,6 +75,9 @@ val connect : ?ownership:[`None | `InOwnsOut | `OutOwnsIn] ->
 val link_close : (_,_) t -> after:(_,_) t -> unit
 (** [link_close p ~after] will close [p] when [after] closes.
     if [after] is closed already, closes [p] immediately *)
+
+val values_available : ('a, [>`r]) t -> availability Lwt.t
+(** [values_available t] tests if data is available in the queue *)
 
 val read : ('a, [>`r]) t -> 'a option Lwt.t
 (** Read the next value from a Pipe *)


### PR DESCRIPTION
Just added a function `values_available`. The idea behind this probably ugly hack is to give the user of the library a blocking function checking for data in the queue, without removing it even when this become available.

The use case is a "read with timeout": I want to read from a pipe but after an amount of time I want to give up. If I simply `Lwt.pick` a timeout and a `read` it doesn't work because if the timeout evaluates before the `read`, a value will be eventually removed and lost.

Instead I `pick` two threads: the timeout and the `values_available`.

```ocaml
let read_pipe_tout ?(timeout=1.0) pipe =
  let timeout () =
    let%lwt () = Lwt_unix.sleep timeout in
    Lwt.return `Timeout in
  let test () =
    match%lwt Lwt_pipe.values_available pipe with
    | Lwt_pipe.Pipe_closed -> Lwt.return `Pipe_closed
    | Lwt_pipe.Nothing_available -> Lwt.return `Nothing_available
    | Lwt_pipe.Data_available -> Lwt.return `Data_available in
  match%lwt Lwt.pick [timeout (); test ()] with
  | `Pipe_closed -> Lwt.return `Eof
  | `Timeout -> Lwt.return `Timeout
  | `Nothing_available -> Lwt.return `Nothing_available
  | `Data_available -> begin
    match%lwt Lwt_pipe.read pipe with
    | Some x -> Lwt.return (`Value_read x)
    | None -> Lwt.return `Eof
  end
```

I don't know if what I wrote is the best way to achieve this goal: I'm totally new to Lwt. In a short test/demo program I wrote it works well but I didn't verify the memory or computational footprint.

P.S. The idea is shamefully stolen from [Async](https://ocaml.janestreet.com/ocaml-core/latest/doc/async_kernel/Async_kernel/Pipe/#val-values_available).